### PR TITLE
fix print float support for GCC

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,7 @@ build_flags           = -DTFT35
   -includeInc/dump_define.h
   -Wp,-w
   -fmax-errors=1
+  -Wl,-u_printf_float
   -Os
   -g3
 board_upload.offset_address = 0x0800C000


### PR DESCRIPTION
I forget to add print float support (to use sprint(bug, "%f", f)). This flag fix it